### PR TITLE
Implement repeat playback functionality with DB-driven count management

### DIFF
--- a/android/app/src/main/java/com/nolbee/memtopic/MainActivity.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/MainActivity.kt
@@ -21,6 +21,7 @@ import com.nolbee.memtopic.database.MockTopicViewModel
 import com.nolbee.memtopic.database.TopicViewModel
 import com.nolbee.memtopic.edit_topic_view.EditTopicViewModel
 import com.nolbee.memtopic.edit_topic_view.EditTopicViewTopAppBar
+import com.nolbee.memtopic.play_topic_view.IPlayTopicViewModel
 import com.nolbee.memtopic.play_topic_view.PlayTopicViewModel
 import com.nolbee.memtopic.play_topic_view.PlayTopicViewTopAppBar
 import com.nolbee.memtopic.topic_list_view.TopicListTopAppBar
@@ -88,7 +89,8 @@ fun MainView(
                     enterTransition = { EnterTransition.None },
                     exitTransition = { ExitTransition.None }
                 ) {
-                    val playTopicViewModel: PlayTopicViewModel = viewModel()
+                    val playTopicViewModel: IPlayTopicViewModel =
+                        hiltViewModel<PlayTopicViewModel>()
                     LaunchedEffect(Unit) {
                         playTopicViewModel.setTopic(topicViewModel.topicToPlay)
                     }
@@ -100,8 +102,6 @@ fun MainView(
         }
     )
 }
-
-private const val TAG = "MainActivity"
 
 @Preview(showBackground = true)
 @Composable

--- a/android/app/src/main/java/com/nolbee/memtopic/database/PlaybackDao.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/database/PlaybackDao.kt
@@ -22,6 +22,7 @@ data class Playback(
     val totalRepetitions: Int,       // How many times the current sentence should be repeated
     val isInterval: Boolean = false, // Whether the current section is the interval
     val content: String = "",
+    // TODO: is playing
 )
 
 @Dao

--- a/android/app/src/main/java/com/nolbee/memtopic/database/PlaybackRepository.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/database/PlaybackRepository.kt
@@ -3,15 +3,16 @@ package com.nolbee.memtopic.database
 import kotlinx.coroutines.flow.Flow
 
 class PlaybackRepository(private val playbackDao: PlaybackDao) {
-    suspend fun upsertPlayback(state: Playback) {
-        playbackDao.upsertPlayback(state)
-    }
-
-    suspend fun getPlaybackOnce(): Playback? {
-        return playbackDao.getPlaybackOnce()
-    }
-
     fun getPlayback(): Flow<Playback?> {
         return playbackDao.getPlayback()
+    }
+
+    suspend fun setCurrentLine(index: Int) {
+        val playback = playbackDao.getPlaybackOnce()
+        if (playback != null) {
+            playbackDao.upsertPlayback(
+                playback.copy(sentenceIndex = index, currentRepetition = 0)
+            )
+        }
     }
 }

--- a/android/app/src/main/java/com/nolbee/memtopic/database/PlaybackRepository.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/database/PlaybackRepository.kt
@@ -1,0 +1,17 @@
+package com.nolbee.memtopic.database
+
+import kotlinx.coroutines.flow.Flow
+
+class PlaybackRepository(private val playbackDao: PlaybackDao) {
+    suspend fun upsertPlayback(state: Playback) {
+        playbackDao.upsertPlayback(state)
+    }
+
+    suspend fun getPlaybackOnce(): Playback? {
+        return playbackDao.getPlaybackOnce()
+    }
+
+    fun getPlayback(): Flow<Playback?> {
+        return playbackDao.getPlayback()
+    }
+}

--- a/android/app/src/main/java/com/nolbee/memtopic/database/TopicDatabase.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/database/TopicDatabase.kt
@@ -70,4 +70,9 @@ object TopicDatabaseModule {
     fun provideTopicRepository(topicDao: TopicDao): TopicRepository {
         return TopicRepository(topicDao)
     }
+
+    @Provides
+    fun providePlaybackRepository(playbackDao: PlaybackDao): PlaybackRepository {
+        return PlaybackRepository(playbackDao)
+    }
 }

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicView.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicView.kt
@@ -21,7 +21,7 @@ import com.nolbee.memtopic.ui.theme.MemTopicTheme
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PlayTopicViewTopAppBar(
-    vm: PlayTopicViewModel,
+    vm: IPlayTopicViewModel,
 ) {
     val playTopicTitle = stringResource(R.string.play_topic_title, vm.topicToPlay.title)
     Scaffold(
@@ -53,7 +53,7 @@ fun PlayTopicViewTopAppBar(
 @Preview
 @Composable
 fun PlayTopicViewTopAppBarPreview() {
-    val vm = PlayTopicViewModel()
+    val vm = MockPlayTopicViewModel()
     vm.setTopic(sampleTopic00)
     MemTopicTheme {
         PlayTopicViewTopAppBar(

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicViewModel.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicViewModel.kt
@@ -4,29 +4,83 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nolbee.memtopic.database.PlaybackRepository
 import com.nolbee.memtopic.database.Topic
 import com.nolbee.memtopic.utils.ContentParser
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class PlayTopicViewModel : ViewModel() {
-    var topicToPlay: Topic by mutableStateOf(Topic())
+interface IPlayTopicViewModel {
+    val topicToPlay: Topic
+    val playableLines: MutableStateFlow<List<String>>
+    val currentLineIndex: MutableStateFlow<Int>
+    fun setTopic(topic: Topic)
+    fun setCurrentLine(index: Int)
+}
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class PlayTopicViewModel @Inject constructor(
+    private val repository: PlaybackRepository
+) : ViewModel(), IPlayTopicViewModel {
+    override var topicToPlay: Topic by mutableStateOf(Topic())
         private set
 
-    var playableLines = MutableStateFlow<List<String>>(emptyList())
+    override var playableLines = MutableStateFlow<List<String>>(emptyList())
         private set
 
-    var currentLineIndex = MutableStateFlow(0)
+    override var currentLineIndex = MutableStateFlow(0)
         private set
 
-    fun setTopic(topic: Topic) {
+    init {
+        viewModelScope.launch {
+            repository.getPlayback().collect { playback ->
+                playback?.let { p ->
+                    currentLineIndex.value = p.sentenceIndex
+                    // TODO: Update topicToPlay from DB
+                }
+            }
+        }
+    }
+
+    override fun setTopic(topic: Topic) {
         this.topicToPlay = topic
         val sentences = ContentParser.parseContentToSentences(topic.content)
         playableLines.update { sentences }
         setCurrentLine(0)
     }
 
-    fun setCurrentLine(index: Int) {
+    override fun setCurrentLine(index: Int) {
+        if (index in playableLines.value.indices) {
+            viewModelScope.launch {
+                repository.setCurrentLine(index)
+            }
+        }
+    }
+}
+
+class MockPlayTopicViewModel : ViewModel(), IPlayTopicViewModel {
+    override var topicToPlay: Topic by mutableStateOf(Topic())
+        private set
+
+    override var playableLines = MutableStateFlow<List<String>>(emptyList())
+        private set
+
+    override var currentLineIndex = MutableStateFlow(0)
+        private set
+
+    override fun setTopic(topic: Topic) {
+        this.topicToPlay = topic
+        val sentences = ContentParser.parseContentToSentences(topic.content)
+        playableLines.update { sentences }
+        setCurrentLine(0)
+    }
+
+    override fun setCurrentLine(index: Int) {
         if (index in playableLines.value.indices) {
             currentLineIndex.value = index
         }

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
@@ -29,7 +29,7 @@ import com.nolbee.memtopic.ui.theme.MemTopicTheme
 
 @Composable
 fun PlayableLineList(
-    vm: PlayTopicViewModel
+    vm: IPlayTopicViewModel
 ) {
     val lines by vm.playableLines.collectAsState(initial = emptyList())
 
@@ -47,7 +47,7 @@ fun PlayableLineList(
 @Preview
 @Composable
 fun PlayableLineListPreview() {
-    val vm = PlayTopicViewModel()
+    val vm = MockPlayTopicViewModel()
     vm.setTopic(sampleTopic02)
     MemTopicTheme {
         PlayableLineList(
@@ -60,7 +60,7 @@ fun PlayableLineListPreview() {
 fun PlayableLineItem(
     index: Int,
     text: String,
-    vm: PlayTopicViewModel,
+    vm: IPlayTopicViewModel,
 ) {
     val context = LocalContext.current
     val currentIndex by vm.currentLineIndex.collectAsState()


### PR DESCRIPTION
#17 

### Summary
- Utilize `OnCompletionListener` to fetch playback info from the database and update the repeat count upon each track completion.
- Allow seamless continuous playback without additional user interaction in between repetitions.

### Major Changes
- Modified `play()` in `AudioPlayerService` to retrieve `Playback` data from `playbackDao.getPlaybackOnce()` on completion.
- Increment the repeat count and re-play the same `audioBase64` if more repetitions remain.
- By persisting the repeat information in the database, playback progress can be restored even after an app or service restart.
