### PR TITLE
Implement icon differentiation for cached items in PlayableLineItem

### DIFF
--- a/android/app/src/main/java/com/nolbee/memtopic/database/AudioCacheDao.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/database/AudioCacheDao.kt
@@ -22,6 +22,6 @@ interface AudioCacheDao {
     @Query("SELECT audioBase64 FROM audiocache WHERE cacheKey = :cacheKey LIMIT 1")
     suspend fun getCachedAudio(cacheKey: String): String?
 
-    @Query("SELECT audioBase64 FROM audiocache WHERE cacheKey IN (:cacheKeys)")
+    @Query("SELECT * FROM audiocache WHERE cacheKey IN (:cacheKeys)")
     fun getCachedAudioByKeys(cacheKeys: List<String>): Flow<List<AudioCache>>
 }

--- a/android/app/src/main/java/com/nolbee/memtopic/database/AudioCacheDao.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/database/AudioCacheDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
 
 @Entity
 data class AudioCache(
@@ -20,4 +21,7 @@ interface AudioCacheDao {
 
     @Query("SELECT audioBase64 FROM audiocache WHERE cacheKey = :cacheKey LIMIT 1")
     suspend fun getCachedAudio(cacheKey: String): String?
+
+    @Query("SELECT audioBase64 FROM audiocache WHERE cacheKey IN (:cacheKeys)")
+    fun getCachedAudioByKeys(cacheKeys: List<String>): Flow<List<AudioCache>>
 }

--- a/android/app/src/main/java/com/nolbee/memtopic/database/AudioCacheRepository.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/database/AudioCacheRepository.kt
@@ -1,0 +1,23 @@
+package com.nolbee.memtopic.database
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class AudioCacheRepository(private val audioCacheDao: AudioCacheDao) {
+    fun getIsCachedLines(lines: List<String>): Flow<List<Boolean>> {
+        val ttsEngine = "gcp" // TODO: get from Topic
+        val languageCode = "en-US" // TODO: get from Topic
+        val voiceType = "en-US-Neural2-J" // TODO: get from Topic
+
+        val cacheKeys = lines.map { line ->
+            "${ttsEngine}_${languageCode}_${voiceType}_${line.hashCode()}"
+        }
+
+        return audioCacheDao.getCachedAudioByKeys(cacheKeys).map { cachedList ->
+            val existingKeys = cachedList.map { it.cacheKey }.toSet()
+            List(lines.size) { index ->
+                cacheKeys[index] in existingKeys
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/nolbee/memtopic/database/TopicDatabase.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/database/TopicDatabase.kt
@@ -75,4 +75,9 @@ object TopicDatabaseModule {
     fun providePlaybackRepository(playbackDao: PlaybackDao): PlaybackRepository {
         return PlaybackRepository(playbackDao)
     }
+
+    @Provides
+    fun provideAudioCacheRepository(audioCacheDao: AudioCacheDao): AudioCacheRepository {
+        return AudioCacheRepository(audioCacheDao)
+    }
 }

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicViewModel.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicViewModel.kt
@@ -17,6 +17,7 @@ import javax.inject.Inject
 interface IPlayTopicViewModel {
     val topicToPlay: Topic
     val playableLines: MutableStateFlow<List<String>>
+    val isCachedLines: MutableStateFlow<List<Boolean>>
     val currentLineIndex: MutableStateFlow<Int>
     fun setTopic(topic: Topic)
     fun setCurrentLine(index: Int)
@@ -31,6 +32,9 @@ class PlayTopicViewModel @Inject constructor(
         private set
 
     override var playableLines = MutableStateFlow<List<String>>(emptyList())
+        private set
+
+    override var isCachedLines = MutableStateFlow<List<Boolean>>(emptyList())
         private set
 
     override var currentLineIndex = MutableStateFlow(-1)
@@ -70,6 +74,9 @@ class MockPlayTopicViewModel : ViewModel(), IPlayTopicViewModel {
         private set
 
     override var playableLines = MutableStateFlow<List<String>>(emptyList())
+        private set
+
+    override var isCachedLines = MutableStateFlow<List<Boolean>>(emptyList())
         private set
 
     override var currentLineIndex = MutableStateFlow(0)

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicViewModel.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicViewModel.kt
@@ -59,8 +59,8 @@ class PlayTopicViewModel @Inject constructor(
         viewModelScope.launch {
             playableLines
                 .flatMapLatest { lines -> audioCacheRepository.getIsCachedLines(lines) }
-                .collect {
-                    list -> isCachedLines.value = list
+                .collect { list ->
+                    isCachedLines.value = list
                     Log.d("PlayTopicViewModel", "isCachedLines: $list")
                 }
         }
@@ -99,6 +99,9 @@ class MockPlayTopicViewModel : ViewModel(), IPlayTopicViewModel {
         this.topicToPlay = topic
         val sentences = ContentParser.parseContentToSentences(topic.content)
         playableLines.update { sentences }
+        val lines = MutableList(minOf(2, sentences.size)) { true }
+        if (sentences.size > 1) lines[1] = false
+        isCachedLines.update { lines }
         setCurrentLine(0)
     }
 

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicViewModel.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayTopicViewModel.kt
@@ -33,15 +33,17 @@ class PlayTopicViewModel @Inject constructor(
     override var playableLines = MutableStateFlow<List<String>>(emptyList())
         private set
 
-    override var currentLineIndex = MutableStateFlow(0)
+    override var currentLineIndex = MutableStateFlow(-1)
         private set
 
     init {
         viewModelScope.launch {
             repository.getPlayback().collect { playback ->
                 playback?.let { p ->
-                    currentLineIndex.value = p.sentenceIndex
-                    // TODO: Update topicToPlay from DB
+                    if (p.topicId != topicToPlay.id)
+                        currentLineIndex.value = -1
+                    else
+                        currentLineIndex.value = p.sentenceIndex
                 }
             }
         }
@@ -51,7 +53,7 @@ class PlayTopicViewModel @Inject constructor(
         this.topicToPlay = topic
         val sentences = ContentParser.parseContentToSentences(topic.content)
         playableLines.update { sentences }
-        setCurrentLine(0)
+        // TODO: If audio player service is not running, setCurrentLine(0)
     }
 
     override fun setCurrentLine(index: Int) {

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
@@ -2,6 +2,12 @@ package com.nolbee.memtopic.play_topic_view
 
 import android.content.Intent
 import android.os.Build
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -20,12 +26,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.nolbee.memtopic.database.sampleTopic02
 import com.nolbee.memtopic.player.AudioPlayerService
@@ -74,6 +86,26 @@ fun PlayableLineItem(
     vm: IPlayTopicViewModel,
 ) {
     val context = LocalContext.current
+
+    var size by remember { mutableStateOf(IntSize.Zero) }
+
+    val infiniteTransition = rememberInfiniteTransition()
+    val offsetAnimX by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = size.width.toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 5000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        )
+    )
+    val offsetAnimY by infiniteTransition.animateFloat(
+        initialValue = size.height.toFloat(),
+        targetValue = 0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 5000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        )
+    )
     val rainbowBrush = Brush.sweepGradient(
         listOf(
             Color.Red,
@@ -83,10 +115,13 @@ fun PlayableLineItem(
             Color.Blue,
             Color.Magenta,
             Color.Red
-        )
+        ),
+        center = Offset(offsetAnimX, offsetAnimY)
     )
     val borderModifier = if (isPlaying) {
-        Modifier.border(BorderStroke(2.dp, rainbowBrush))
+        Modifier
+            .border(BorderStroke(2.dp, rainbowBrush))
+            .onSizeChanged { size = it }
     } else {
         Modifier
     }

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
@@ -158,7 +158,12 @@ fun PlayableLineItem(
                     true -> Icons.Default.FileDownloadDone
                     null -> Icons.Default.QuestionMark
                 }
-                Icon(imageVector = icon, contentDescription = null)
+                val tint = when (isCached) {
+                    false -> Color(0xFF8080A0)
+                    true -> Color(0xFF00A000)
+                    null -> Color(0xFFA06060)
+                }
+                Icon(imageVector = icon, contentDescription = null, tint = tint)
             }
         )
         HorizontalDivider()

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
@@ -2,10 +2,11 @@ package com.nolbee.memtopic.play_topic_view
 
 import android.content.Intent
 import android.os.Build
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
@@ -19,11 +20,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.nolbee.memtopic.database.sampleTopic02
 import com.nolbee.memtopic.player.AudioPlayerService
 import com.nolbee.memtopic.ui.theme.MemTopicTheme
@@ -71,7 +74,27 @@ fun PlayableLineItem(
     vm: IPlayTopicViewModel,
 ) {
     val context = LocalContext.current
-    Column {
+    val rainbowBrush = Brush.sweepGradient(
+        listOf(
+            Color.Red,
+            Color.Yellow,
+            Color.Green,
+            Color.Cyan,
+            Color.Blue,
+            Color.Magenta,
+            Color.Red
+        )
+    )
+    val borderModifier = if (isPlaying) {
+        Modifier.border(BorderStroke(2.dp, rainbowBrush))
+    } else {
+        Modifier
+    }
+
+    Column(
+        modifier = borderModifier
+            .fillMaxWidth()
+    ) {
         ListItem(
             modifier = Modifier
                 .fillMaxWidth()
@@ -93,16 +116,6 @@ fun PlayableLineItem(
                     text = text,
                     fontWeight = if (isPlaying) FontWeight.Bold else FontWeight.Normal
                 )
-            },
-            supportingContent = {
-                if (isPlaying) {
-                    Text(
-                        text = "Playing...",
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .wrapContentWidth(Alignment.End)
-                    )
-                }
             },
             leadingContent = {
                 val icon = when (isCached) {

--- a/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/play_topic_view/PlayableLineView.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowCircleDown
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.FileDownloadDone
+import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -32,12 +34,16 @@ fun PlayableLineList(
     vm: IPlayTopicViewModel
 ) {
     val lines by vm.playableLines.collectAsState(initial = emptyList())
+    val currentIndex by vm.currentLineIndex.collectAsState()
+    val isCachedLines by vm.isCachedLines.collectAsState(emptyList())
 
     LazyColumn {
         itemsIndexed(lines) { index, text ->
             PlayableLineItem(
                 index = index,
                 text = text,
+                isPlaying = currentIndex == index,
+                isCached = isCachedLines.getOrNull(index),
                 vm = vm,
             )
         }
@@ -60,11 +66,11 @@ fun PlayableLineListPreview() {
 fun PlayableLineItem(
     index: Int,
     text: String,
+    isPlaying: Boolean,
+    isCached: Boolean?,
     vm: IPlayTopicViewModel,
 ) {
     val context = LocalContext.current
-    val currentIndex by vm.currentLineIndex.collectAsState()
-    val isPlaying = currentIndex == index
     Column {
         ListItem(
             modifier = Modifier
@@ -99,10 +105,12 @@ fun PlayableLineItem(
                 }
             },
             leadingContent = {
-                Icon(
-                    imageVector = Icons.Filled.ArrowCircleDown,
-                    contentDescription = "Select line"
-                )
+                val icon = when (isCached) {
+                    false -> Icons.Default.Cloud
+                    true -> Icons.Default.FileDownloadDone
+                    null -> Icons.Default.QuestionMark
+                }
+                Icon(imageVector = icon, contentDescription = null)
             }
         )
         HorizontalDivider()


### PR DESCRIPTION
- Only show the currently playing indicator when the topic matches, and add animations
- Add DB queries and ViewModel subscriptions to display icons for cached items

Resolves #15, #18 