### PR TITLE
Refactor AudioPlayerService to use AudioPlayer class

### DIFF
--- a/android/app/src/main/java/com/nolbee/memtopic/database/PlaybackDao.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/database/PlaybackDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.Upsert
+import com.nolbee.memtopic.utils.ContentParser
 import kotlinx.coroutines.flow.Flow
 
 /*
@@ -23,7 +24,19 @@ data class Playback(
     val isInterval: Boolean = false, // Whether the current section is the interval
     val content: String = "",
     // TODO: is playing
-)
+) {
+    fun next(): Playback {
+        return if (currentRepetition < totalRepetitions - 1) {
+            copy(currentRepetition = currentRepetition + 1)
+        } else {
+            val sentences = ContentParser.parseContentToSentences(content)
+            copy(
+                sentenceIndex = (sentenceIndex + 1) % sentences.size,
+                currentRepetition = 0
+            )
+        }
+    }
+}
 
 @Dao
 interface PlaybackDao {

--- a/android/app/src/main/java/com/nolbee/memtopic/player/AudioPlayer.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/player/AudioPlayer.kt
@@ -1,0 +1,138 @@
+package com.nolbee.memtopic.player
+
+import android.content.Context
+import android.media.MediaPlayer
+import android.util.Log
+import com.nolbee.memtopic.account_view.SecureKeyValueStore
+import com.nolbee.memtopic.client.TextToSpeechGCP
+import com.nolbee.memtopic.database.AudioCache
+import com.nolbee.memtopic.database.AudioCacheDao
+import com.nolbee.memtopic.database.Playback
+import com.nolbee.memtopic.database.PlaybackDao
+import com.nolbee.memtopic.database.TopicDao
+import com.nolbee.memtopic.utils.ContentParser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class AudioPlayer(
+    private val playbackDao: PlaybackDao,
+    private val topicDao: TopicDao,
+    private val audioCacheDao: AudioCacheDao,
+    private val applicationContext: Context,
+    private val onUpdateNotification: () -> Unit,
+) {
+    private val mediaPlayer: MediaPlayer = MediaPlayer()
+    private val serviceScope = CoroutineScope(Dispatchers.IO + Job())
+    var notificationTitle: String = "Audio Player"
+    var notificationText: String = "Sentence: 0/0, Repetition: 0/0"
+
+    private suspend fun getOrSynthesizeAudioForLine(playback: Playback): String {
+        val ttsEngine = "gcp" // TODO: get from Topic if needed
+        val languageCode = "en-US" // TODO: get from Topic
+        val voiceType = "en-US-Neural2-J" // TODO: get from Topic
+
+        val sentences = ContentParser.parseContentToSentences(playback.content)
+        val sentence = sentences[playback.sentenceIndex]
+
+        val cacheKey = "${ttsEngine}_${languageCode}_${voiceType}_${sentence.hashCode()}"
+        val cached = audioCacheDao.getCachedAudio(cacheKey)
+        if (cached != null) {
+            return cached
+        } else {
+            val apiKey = SecureKeyValueStore(applicationContext).get("gcpTextToSpeechToken") ?: ""
+            val audioBase64 = TextToSpeechGCP(apiKey, languageCode, voiceType).synthesize(sentence)
+            audioCacheDao.upsertCache(AudioCache(cacheKey, audioBase64))
+            return audioBase64
+        }
+    }
+
+    private suspend fun updateCurrentPlayback(topicId: Int, sentenceIndex: Int): Playback {
+        val topic = topicDao.getTopic(topicId)
+        if (topic == null) {
+            val msg = "Topic not found for ID: $topicId"
+            Log.e("AudioPlayer", msg)
+            notificationTitle = "Error"
+            notificationText = msg
+            throw Exception(msg)
+        }
+        val sentences = ContentParser.parseContentToSentences(topic.content)
+        val repetition = 0
+        val totalRepetitions = 2 // TODO: get from Player Setting
+        notificationTitle = topic.title
+        notificationText =
+            "Sentence: ${sentenceIndex + 1}/${sentences.size}, Repetition: ${repetition + 1}/$totalRepetitions"
+        val playback = Playback(
+            topicId = topicId,
+            sentenceIndex = sentenceIndex,
+            currentRepetition = repetition,
+            totalRepetitions = totalRepetitions,
+            isInterval = false,
+            content = topic.content,
+        )
+        playbackDao.upsertPlayback(playback)
+        return playback
+    }
+
+    private val onCompletionListener = MediaPlayer.OnCompletionListener {
+        serviceScope.launch {
+            val currPlayback = playbackDao.getPlaybackOnce()
+            if (currPlayback == null) {
+                val msg = "Playback not found"
+                Log.e("AudioPlayer", msg)
+                notificationTitle = "Error"
+                notificationText = msg
+                return@launch
+            }
+            val nextPlayback = currPlayback.next()
+            val sentences = ContentParser.parseContentToSentences(nextPlayback.content)
+            val sentenceIndex = nextPlayback.sentenceIndex
+            val repetition = nextPlayback.currentRepetition
+            val totalRepetitions = nextPlayback.totalRepetitions
+            notificationText =
+                "Sentence: ${sentenceIndex + 1}/${sentences.size}, Repetition: ${repetition + 1}/$totalRepetitions"
+            playbackDao.upsertPlayback(nextPlayback)
+            playAudioLoop(nextPlayback)
+        }
+    }
+
+    private suspend fun playAudioLoop(playback: Playback) {
+        val audioBase64 = getOrSynthesizeAudioForLine(playback)
+        withContext(Dispatchers.Main) {
+            onUpdateNotification()
+            mediaPlayer.apply {
+                reset()
+                setDataSource("data:audio/mp3;base64,$audioBase64")
+                prepare()
+                start()
+                setOnCompletionListener(onCompletionListener)
+            }
+        }
+    }
+
+    fun play(topicId: Int, sentenceIndex: Int) {
+        if (mediaPlayer.isPlaying) {
+            mediaPlayer.stop()
+        }
+        serviceScope.launch {
+            try {
+                val playback = updateCurrentPlayback(topicId, sentenceIndex)
+                playAudioLoop(playback)
+            } catch (e: Exception) {
+                onUpdateNotification()
+            }
+        }
+    }
+
+    fun stop() {
+        mediaPlayer.takeIf { it.isPlaying }?.stop()
+    }
+
+    fun release() {
+        mediaPlayer.release()
+        serviceScope.cancel()
+    }
+}

--- a/android/app/src/main/java/com/nolbee/memtopic/player/AudioPlayerService.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/player/AudioPlayerService.kt
@@ -1,40 +1,26 @@
 package com.nolbee.memtopic.player
 
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
-import android.media.MediaPlayer
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.media.app.NotificationCompat.MediaStyle
-import com.nolbee.memtopic.account_view.SecureKeyValueStore
-import com.nolbee.memtopic.client.TextToSpeechGCP
-import com.nolbee.memtopic.database.AudioCache
 import com.nolbee.memtopic.database.AudioCacheDao
-import com.nolbee.memtopic.database.Playback
 import com.nolbee.memtopic.database.PlaybackDao
 import com.nolbee.memtopic.database.TopicDao
-import com.nolbee.memtopic.utils.ContentParser
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
-
-// TODO: Notification 권한 요청
 
 @AndroidEntryPoint
 class AudioPlayerService : Service() {
     companion object {
         const val ACTION_UPDATE = "ACTION_UPDATE"
-        const val ACTION_PLAY = "ACTION_PLAY"
         const val ACTION_EXIT = "ACTION_EXIT"
         const val KEY_TOPIC_ID = "KEY_TOPIC_ID"
         const val KEY_SENTENCE_ID = "KEY_SENTENCE_ID"
@@ -51,13 +37,14 @@ class AudioPlayerService : Service() {
     @Inject
     lateinit var audioCacheDao: AudioCacheDao
 
-    private var mediaPlayer: MediaPlayer? = null
-    private val serviceScope = CoroutineScope(Dispatchers.IO + Job())
+    private lateinit var audioPlayer: AudioPlayer
 
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
-        mediaPlayer = MediaPlayer()
+        audioPlayer = AudioPlayer(playbackDao, topicDao, audioCacheDao, applicationContext) {
+            updateNotification()
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -66,34 +53,11 @@ class AudioPlayerService : Service() {
                 val topicId = intent.getIntExtra(KEY_TOPIC_ID, -1)
                 val sentenceIndex = intent.getIntExtra(KEY_SENTENCE_ID, -1)
                 Log.d("AudioPlayerService", "topicId: $topicId, sentenceIndex: $sentenceIndex")
-                serviceScope.launch {
-                    topicDao.getTopic(topicId)?.let { topic ->
-                        val playback = Playback(
-                            topicId = topicId,
-                            sentenceIndex = sentenceIndex,
-                            currentRepetition = 0,
-                            totalRepetitions = 2,
-                            isInterval = false,
-                            content = topic.content,
-                        )
-                        playbackDao.upsertPlayback(playback)
-                        play(playback)
-                    }
-                }
-            }
-
-            ACTION_PLAY -> {
-                serviceScope.launch {
-                    try {
-                        playbackDao.getPlaybackOnce()?.let { playback -> play(playback) }
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                    }
-                }
+                audioPlayer.play(topicId, sentenceIndex)
             }
 
             ACTION_EXIT -> {
-                stopMedia()
+                audioPlayer.stop()
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
                 return START_NOT_STICKY
@@ -103,119 +67,40 @@ class AudioPlayerService : Service() {
         return START_NOT_STICKY
     }
 
-    private suspend fun play(playback: Playback) {
-        val ttsEngine = "gcp" // TODO: get from Topic
-        val languageCode = "en-US" // TODO: get from Topic
-        val voiceType = "en-US-Neural2-J" // TODO: get from Topic
-        // TODO: out of index handling
-        val sentence =
-            ContentParser.parseContentToSentences(playback.content)[playback.sentenceIndex]
-
-        val cacheKey = "${ttsEngine}_${languageCode}_${voiceType}_${sentence.hashCode()}"
-        val cached = audioCacheDao.getCachedAudio(cacheKey)
-        if (cached != null) {
-            Log.d("AudioPlayerService", "cache hit")
-            withContext(Dispatchers.Main) {
-                play(cached)
-            }
-        } else {
-            Log.d("AudioPlayerService", "cache miss")
-            val apiKey = SecureKeyValueStore(applicationContext).get("gcpTextToSpeechToken") ?: ""
-            val audioBase64 = TextToSpeechGCP(apiKey, languageCode, voiceType).synthesize(sentence)
-            audioCacheDao.upsertCache(AudioCache(cacheKey, audioBase64))
-            withContext(Dispatchers.Main) {
-                play(audioBase64)
-            }
-        }
-    }
-
-    private fun play(audioBase64: String) {
-        if (mediaPlayer?.isPlaying == true) return
-
-        mediaPlayer?.apply {
-            reset()
-            setDataSource("data:audio/mp3;base64,$audioBase64")
-            prepare()
-            start()
-            setOnCompletionListener {
-                serviceScope.launch {
-                    try {
-                        playbackDao.getPlaybackOnce()?.let { p ->
-                            val playback: Playback
-                            if (p.currentRepetition < p.totalRepetitions - 1) {
-                                playback = Playback(
-                                    topicId = p.topicId,
-                                    sentenceIndex = p.sentenceIndex,
-                                    currentRepetition = p.currentRepetition + 1,
-                                    totalRepetitions = p.totalRepetitions,
-                                    isInterval = p.isInterval,
-                                    content = p.content,
-                                )
-                            } else {
-                                val sentences = ContentParser.parseContentToSentences(p.content)
-                                playback = Playback(
-                                    topicId = p.topicId,
-                                    sentenceIndex = (p.sentenceIndex + 1) % sentences.size,
-                                    currentRepetition = 0,
-                                    totalRepetitions = p.totalRepetitions,
-                                    isInterval = p.isInterval,
-                                    content = p.content,
-                                )
-                            }
-                            playbackDao.upsertPlayback(playback)
-                            play(playback)
-                        }
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                    }
-                }
-            }
-        }
-    }
-
-    private fun stopMedia() {
-        mediaPlayer?.takeIf { it.isPlaying }?.stop()
-    }
-
     override fun onDestroy() {
-        mediaPlayer?.release()
-        mediaPlayer = null
-        serviceScope.cancel()
+        audioPlayer.release()
         super.onDestroy()
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    private fun buildNotification() = NotificationCompat.Builder(this, CHANNEL_ID)
-        .setSmallIcon(android.R.drawable.ic_lock_silent_mode_off)
-        .setContentTitle("Audio Player")
-        .setContentText("Playing Audio")
-        .setStyle(MediaStyle().setShowActionsInCompactView(0, 1))
-        .setOngoing(true)
-        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-        .addAction(
-            NotificationCompat.Action(
-                android.R.drawable.ic_media_play,
-                "Play",
-                PendingIntent.getService(
-                    this, 0,
-                    Intent(this, AudioPlayerService::class.java).apply { action = ACTION_PLAY },
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
+    private fun updateNotification() {
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        manager.notify(NOTIFICATION_ID, buildNotification())
+    }
+
+    private fun buildNotification(): Notification {
+        val exitAction = NotificationCompat.Action(
+            android.R.drawable.ic_menu_close_clear_cancel,
+            "Exit",
+            PendingIntent.getService(
+                this, 0,
+                Intent(this, AudioPlayerService::class.java).apply { action = ACTION_EXIT },
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         )
-        .addAction(
-            NotificationCompat.Action(
-                android.R.drawable.ic_menu_close_clear_cancel,
-                "Exit",
-                PendingIntent.getService(
-                    this, 0,
-                    Intent(this, AudioPlayerService::class.java).apply { action = ACTION_EXIT },
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-            )
-        )
-        .build()
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_lock_silent_mode_off)
+            .setContentTitle(audioPlayer.notificationTitle)
+            .setContentText(audioPlayer.notificationText)
+            .setStyle(MediaStyle().setShowActionsInCompactView(0))
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .addAction(exitAction)
+            .setShowWhen(false)
+            .build()
+    }
 
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
This commit introduces an `AudioPlayer` class to encapsulate the audio playback logic, improving code organization and maintainability.
- The `AudioPlayerService` now uses this `AudioPlayer` instance.
- The `AudioPlayer` class handles audio synthesis, caching, and playback logic, as well as managing the media player and coroutines.
- `AudioPlayer` manages the notification message.
- Update `Playback` to support `next()` to get next `Playback` instance.
- Remove unused method and class.

#17 