### PR TITLE
Refactor EditTopicView and set windowSoftInputMode to adjustResize

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true"
             android:theme="@style/Theme.MemTopic">
             <intent-filter>

--- a/android/app/src/main/java/com/nolbee/memtopic/edit_topic_view/EditTopicView.kt
+++ b/android/app/src/main/java/com/nolbee/memtopic/edit_topic_view/EditTopicView.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.AlertDialogDefaults
@@ -29,7 +27,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -119,22 +116,17 @@ private fun TopicTitleTextField(editTopicViewModel: EditTopicViewModel) {
         readOnly = !editTopicViewModel.isNew,
         singleLine = true,
         label = { Text("제목") },  // TODO: replace this string with a string resource to achieve multi-language support.
-        visualTransformation = VisualTransformation.None,
     )
 }
 
 @Composable
 private fun TopicContentTextField(editTopicViewModel: EditTopicViewModel) {
-    val scrollState = rememberScrollState()
     TextField(
         value = editTopicViewModel.topicContent,
         onValueChange = { editTopicViewModel.updateContent(it) },
-        modifier = Modifier
-            .fillMaxSize(1f)
-            .verticalScroll(scrollState),
-        singleLine = false,
+        modifier = Modifier.fillMaxSize(),
+        maxLines = Int.MAX_VALUE,
         label = { Text("내용") },  // TODO: replace this string with a string resource to achieve multi-language support.
-        visualTransformation = VisualTransformation.None,
     )
 }
 


### PR DESCRIPTION
- Removed unnecessary scroll state and single line limitation from TopicContentTextField.
- Set `android:windowSoftInputMode` to `adjustResize` in `AndroidManifest.xml` to resize the layout when the soft keyboard appears.

resolves #26